### PR TITLE
Feature/support ubuntu 18.04

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -13,3 +13,10 @@
     state: restarted
   tags:
       - dnsmasq
+
+- name: restart systemd-resolved
+  service:
+    name: systemd-resolved
+    state: restarted
+  tags:
+      - dnsmasq

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,10 +42,10 @@
 # On installations that use systemd-resolved, we need to add a file
 # to /etc/systemd/resolved.conf.d
 
-- name: make sure resolved.conf.d directory exists
-  file:
-    dest: /etc/systemd/resolved.conf.d
-    state: directory
+# - name: make sure resolved.conf.d directory exists
+#   file:
+#     dest: /etc/systemd/resolved.conf.d
+#     state: directory
 
 - name: check if the systemd-resolved service exists
   shell: service systemd-resolved status
@@ -55,12 +55,28 @@
     - dnsmasq
     - dnsmasq-start-and-enable-service
 
-- name: ensure that the systemd-resolved custom config file exists
+# - name: ensure that the systemd-resolved custom config file exists
+#   copy:
+#     dest: /etc/systemd/resolved.conf.d/dnsmasq.conf
+#     content: "[Resolve]\nDNS={{ dnsmasq_listen_address }}\n"
+#   when: systemd_resolved_status.rc == 0
+#   notify: restart systemd-resolved
+#   tags:
+#     - dnsmasq
+#     - dnsmasq-start-and-enable-service
+
+# On installations that use systemd-resolved, disable it and configure /etc/resolv.conf to use the dnsmasq address instead
+
+- name: make sure that /etc/resolv.conf points to 127.0.0.1
   copy:
-    dest: /etc/systemd/resolved.conf.d/dnsmasq.conf
-    content: "[Resolve]\nDNS={{ dnsmasq_listen_address }}\n"
-  when: systemd_resolved_status.rc == 0
-  notify: restart systemd-resolved
+    dest: /etc/resolv.conf
+    content: "nameserver 127.0.0.1\nsearch ec2.internal\n"
   tags:
     - dnsmasq
-    - dnsmasq-start-and-enable-service
+
+- name: disable systemd-resolved
+  service:
+    name: systemd-resolved
+    state: stopped
+    enabled: no
+  when: systemd_resolved_status.rc == 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,13 +39,16 @@
   when: not ansible_os_family == 'Debian'
 
 
-# On installations that use systemd-resolved, we need to add a file
-# to /etc/systemd/resolved.conf.d
+# On installations that use systemd-resolved, we need to make sure
+# that /etc/resolv.conf points directly to dnsmasq and then
+# disable systemd-resolved
 
-# - name: make sure resolved.conf.d directory exists
-#   file:
-#     dest: /etc/systemd/resolved.conf.d
-#     state: directory
+- name: make sure that /etc/resolv.conf points to 127.0.0.1
+  copy:
+    dest: /etc/resolv.conf
+    content: "nameserver 127.0.0.1\nsearch ec2.internal\n"
+  tags:
+    - dnsmasq
 
 - name: check if the systemd-resolved service exists
   shell: service systemd-resolved status
@@ -54,25 +57,6 @@
   tags:
     - dnsmasq
     - dnsmasq-start-and-enable-service
-
-# - name: ensure that the systemd-resolved custom config file exists
-#   copy:
-#     dest: /etc/systemd/resolved.conf.d/dnsmasq.conf
-#     content: "[Resolve]\nDNS={{ dnsmasq_listen_address }}\n"
-#   when: systemd_resolved_status.rc == 0
-#   notify: restart systemd-resolved
-#   tags:
-#     - dnsmasq
-#     - dnsmasq-start-and-enable-service
-
-# On installations that use systemd-resolved, disable it and configure /etc/resolv.conf to use the dnsmasq address instead
-
-- name: make sure that /etc/resolv.conf points to 127.0.0.1
-  copy:
-    dest: /etc/resolv.conf
-    content: "nameserver 127.0.0.1\nsearch ec2.internal\n"
-  tags:
-    - dnsmasq
 
 - name: disable systemd-resolved
   service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,7 +44,7 @@
 - name: check if the systemd-resolved service exists
   shell: service systemd-resolved status
   register: systemd_resolved_status
-  failed_when: not(systemd_resolved.rc == 3 or systemd_resolved.rc == 0)
+  failed_when: not(systemd_resolved_status.rc == 3 or systemd_resolved_status.rc == 0)
   tags:
     - dnsmasq
     - dnsmasq-start-and-enable-service
@@ -53,7 +53,7 @@
   copy:
     dest: /etc/systemd/resolved.conf.d/dnsmasq.conf
     content: "[Resolve]\nDNS={{ dnsmasq_listen_address }}\n"
-  when: systemd_resolved.rc == 0
+  when: systemd_resolved_status.rc == 0
   notify: restart systemd-resolved
   tags:
     - dnsmasq

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,6 +41,12 @@
 
 # On installations that use systemd-resolved, we need to add a file
 # to /etc/systemd/resolved.conf.d
+
+- name: make sure resolved.conf.d directory exists
+  file:
+    dest: /etc/systemd/resolved.conf.d
+    state: directory
+
 - name: check if the systemd-resolved service exists
   shell: service systemd-resolved status
   register: systemd_resolved_status

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,3 +37,24 @@
 # in resolv.conf and restart networking services.
 - include: dhclient.yml
   when: not ansible_os_family == 'Debian'
+
+
+# On installations that use systemd-resolved, we need to add a file
+# to /etc/systemd/resolved.conf.d
+- name: check if the systemd-resolved service exists
+  shell: service systemd-resolved status
+  register: systemd_resolved_status
+  failed_when: not(systemd_resolved.rc == 3 or systemd_resolved.rc == 0)
+  tags:
+    - dnsmasq
+    - dnsmasq-start-and-enable-service
+
+- name: ensure that the systemd-resolved custom config file exists
+  ini_file:
+    dest: /etc/systemd/resolved.conf.d/dnsmasq.conf
+    content: "[Resolve]\nDNS={{ dnsmasq_listen_address }}\n"
+  when: systemd_resolved.rc == 0
+  notify: restart systemd-resolved
+  tags:
+    - dnsmasq
+    - dnsmasq-start-and-enable-service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,7 +24,7 @@
 - name: start and enable dnsmasq service
   service:
     name: dnsmasq
-    state: started
+    state: restarted
     enabled: true
   tags:
       - dnsmasq

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,7 +50,7 @@
     - dnsmasq-start-and-enable-service
 
 - name: ensure that the systemd-resolved custom config file exists
-  ini_file:
+  copy:
     dest: /etc/systemd/resolved.conf.d/dnsmasq.conf
     content: "[Resolve]\nDNS={{ dnsmasq_listen_address }}\n"
   when: systemd_resolved.rc == 0

--- a/templates/etc/dnsmasq.conf.j2
+++ b/templates/etc/dnsmasq.conf.j2
@@ -13,6 +13,8 @@ listen-address={{ dnsmasq_listen_address }}
 # dns lookups for specified domains
 cache-size={{ dnsmasq_cache_size }}
 
+server=169.254.169.253
+
 {% for address in dnsmasq_server_addresses %}
 server={{ address }}
 {% endfor %}


### PR DESCRIPTION
This adds a check to see if the `systemd-resolved` service is present, and if so configures it to point to the dnsmasq listen address. 