### PR TITLE
Check for exit code 4 from systemd-resolved service

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,7 +53,7 @@
 - name: check if the systemd-resolved service exists
   shell: service systemd-resolved status
   register: systemd_resolved_status
-  failed_when: not(systemd_resolved_status.rc == 3 or systemd_resolved_status.rc == 0)
+  failed_when: not(systemd_resolved_status.rc == 4 or systemd_resolved_status.rc == 3 or systemd_resolved_status.rc == 0)
   tags:
     - dnsmasq
     - dnsmasq-start-and-enable-service


### PR DESCRIPTION
The `service` command on Amazon Linux 2 (and probably other RHEL flavors) returns exit code 4 for unknown services and systemd-resolved doesn't even exist on that distro.